### PR TITLE
Make AuroraLib.Core nullable

### DIFF
--- a/Benchmark/Benchmarks/ReadStruct.cs
+++ b/Benchmark/Benchmarks/ReadStruct.cs
@@ -12,7 +12,7 @@ namespace Benchmark.Benchmarks
         private const int n = 1000;
         private const int SIZE = 16;
 
-        private Stream stream;
+        private Stream stream = Stream.Null;
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/CoreTest/CoreUnitTest.csproj
+++ b/CoreTest/CoreUnitTest.csproj
@@ -3,8 +3,13 @@
   <PropertyGroup>
 	<TargetFrameworks>net8.0;net6.0;net472;</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AuroraLib.Core/AuroraLib.Core.csproj
+++ b/src/AuroraLib.Core/AuroraLib.Core.csproj
@@ -4,6 +4,7 @@
     <AssemblyTitle>AuroraLib.Core</AssemblyTitle>
     <TargetFrameworks>net8.0;net6.0;netstandard2.0;net472;</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Title>AuroraLib.Core</Title>
 	<Version>1.4.2.3</Version>
@@ -39,6 +40,10 @@
 	<PropertyGroup>
 		<NETFrameworks>|netstandard2.0|net481|net48|net472|NET471|NET47|NET462|NET461|</NETFrameworks>
 	</PropertyGroup>
+
+  <PropertyGroup Condition="$(NETFrameworks.Contains('|$(TargetFramework)|'))">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
 
 	<ItemGroup Condition="$(NETFrameworks.Contains('|$(TargetFramework)|'))">
 		<PackageReference Include="System.Memory" Version="4.5.5" />

--- a/src/AuroraLib.Core/BitConverterX.cs
+++ b/src/AuroraLib.Core/BitConverterX.cs
@@ -133,7 +133,7 @@ namespace AuroraLib.Core
         {
             lock (TypePrimitives)
             {
-                if (TypePrimitives.TryGetValue(type.GetHashCode(), out int[] primitives))
+                if (TypePrimitives.TryGetValue(type.GetHashCode(), out int[]? primitives))
                     return primitives;
 
                 return NewPrimitiveTypeSizes(type);

--- a/src/AuroraLib.Core/IO/BitStreamProcessor.cs
+++ b/src/AuroraLib.Core/IO/BitStreamProcessor.cs
@@ -24,7 +24,7 @@ namespace AuroraLib.Core.IO
             }
             protected set => basestream = value;
         }
-        private Stream basestream;
+        private Stream basestream = Stream.Null;
 
         /// <inheritdoc cref="Stream.Length"/>
         public long Length => basestream.Length;

--- a/src/AuroraLib.Core/Identifier.cs
+++ b/src/AuroraLib.Core/Identifier.cs
@@ -35,10 +35,10 @@ namespace AuroraLib.Core
         public Span<byte> AsSpan() => Bytes.AsSpan();
 
         /// <inheritdoc />
-        public bool Equals(string other) => other == GetString();
+        public bool Equals(string? other) => other == GetString();
 
         /// <inheritdoc />
-        public bool Equals(IIdentifier other) => other != null && other.AsSpan().SequenceEqual(AsSpan());
+        public bool Equals(IIdentifier? other) => other != null && other.AsSpan().SequenceEqual(AsSpan());
 
         /// <inheritdoc />
         [DebuggerStepThrough]

--- a/src/AuroraLib.Core/Identifier32.cs
+++ b/src/AuroraLib.Core/Identifier32.cs
@@ -124,10 +124,10 @@ namespace AuroraLib.Core
             => EncodingX.GetCString(AsSpan(), encoding, 0x0);
 
         /// <inheritdoc />
-        public bool Equals(string other) => other == GetString();
+        public bool Equals(string? other) => other == GetString();
 
         /// <inheritdoc />
-        public bool Equals(IIdentifier other) => other != null && other.AsSpan().SequenceEqual(AsSpan());
+        public bool Equals(IIdentifier? other) => other != null && other.AsSpan().SequenceEqual(AsSpan());
 
         public static implicit operator Identifier32(uint v) => *(Identifier32*)&v;
         public static implicit operator uint(Identifier32 v) => *(uint*)&v;

--- a/src/AuroraLib.Core/Identifier64.cs
+++ b/src/AuroraLib.Core/Identifier64.cs
@@ -124,10 +124,10 @@ namespace AuroraLib.Core
             => EncodingX.GetCString(AsSpan(), encoding, 0x0);
 
         /// <inheritdoc />
-        public bool Equals(string other) => other == GetString();
+        public bool Equals(string? other) => other == GetString();
 
         /// <inheritdoc />
-        public bool Equals(IIdentifier other) => other != null && other.AsSpan().SequenceEqual(AsSpan());
+        public bool Equals(IIdentifier? other) => other != null && other.AsSpan().SequenceEqual(AsSpan());
 
         public static implicit operator Identifier64(ulong v) => *(Identifier64*)&v;
         public static implicit operator ulong(Identifier64 v) => *(ulong*)&v;

--- a/src/AuroraLib.Core/Int24.cs
+++ b/src/AuroraLib.Core/Int24.cs
@@ -52,16 +52,16 @@ namespace AuroraLib.Core
         public override string ToString() => Value.ToString();
 
         /// <inheritdoc/>
-        public string ToString(IFormatProvider provider) => Value.ToString(provider);
+        public string ToString(IFormatProvider? provider) => Value.ToString(provider);
 
         /// <inheritdoc/>
-        public string ToString(string format) => Value.ToString(format);
+        public string ToString(string? format) => Value.ToString(format);
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider provider) => Value.ToString(format, provider);
+        public string ToString(string? format, IFormatProvider? provider) => Value.ToString(format, provider);
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Int24 i24 && i24.Value == Value;
+        public override bool Equals(object? obj) => obj is Int24 i24 && i24.Value == Value;
 
         /// <inheritdoc/>
         public bool Equals(Int24 other) => this == other;
@@ -73,7 +73,7 @@ namespace AuroraLib.Core
         public override int GetHashCode() => Value.GetHashCode();
 
         /// <inheritdoc/>
-        public int CompareTo(object value)
+        public int CompareTo(object? value)
         {
             if (value == null)
             {
@@ -141,49 +141,49 @@ namespace AuroraLib.Core
 
         #region IConvertible
 
-        bool IConvertible.ToBoolean(IFormatProvider provider)
+        bool IConvertible.ToBoolean(IFormatProvider? provider)
             => Convert.ToBoolean(Value, provider);
 
-        char IConvertible.ToChar(IFormatProvider provider)
+        char IConvertible.ToChar(IFormatProvider? provider)
             => Convert.ToChar(Value, provider);
 
-        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        sbyte IConvertible.ToSByte(IFormatProvider? provider)
             => Convert.ToSByte(Value, provider);
 
-        byte IConvertible.ToByte(IFormatProvider provider)
+        byte IConvertible.ToByte(IFormatProvider? provider)
             => Convert.ToByte(Value, provider);
 
-        short IConvertible.ToInt16(IFormatProvider provider)
+        short IConvertible.ToInt16(IFormatProvider? provider)
             => Convert.ToInt16(Value, provider);
 
-        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        ushort IConvertible.ToUInt16(IFormatProvider? provider)
             => Convert.ToUInt16(Value, provider);
 
-        int IConvertible.ToInt32(IFormatProvider provider)
+        int IConvertible.ToInt32(IFormatProvider? provider)
             => Value;
 
-        uint IConvertible.ToUInt32(IFormatProvider provider)
+        uint IConvertible.ToUInt32(IFormatProvider? provider)
             => Convert.ToUInt32(Value, provider);
 
-        long IConvertible.ToInt64(IFormatProvider provider)
+        long IConvertible.ToInt64(IFormatProvider? provider)
             => Convert.ToInt64(Value, provider);
 
-        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        ulong IConvertible.ToUInt64(IFormatProvider? provider)
             => Convert.ToUInt64(Value, provider);
 
-        float IConvertible.ToSingle(IFormatProvider provider)
+        float IConvertible.ToSingle(IFormatProvider? provider)
             => Convert.ToSingle(Value, provider);
 
-        double IConvertible.ToDouble(IFormatProvider provider)
+        double IConvertible.ToDouble(IFormatProvider? provider)
             => Convert.ToDouble(Value, provider);
 
-        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        decimal IConvertible.ToDecimal(IFormatProvider? provider)
             => Convert.ToDecimal(Value, provider);
 
-        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        DateTime IConvertible.ToDateTime(IFormatProvider? provider)
             => Convert.ToDateTime(Value, provider);
 
-        object IConvertible.ToType(Type type, IFormatProvider provider)
+        object IConvertible.ToType(Type type, IFormatProvider? provider)
             => Convert.ChangeType(Value, type, provider);
 
         /// <inheritdoc/>

--- a/src/AuroraLib.Core/Text/ValueStringBuilder.cs
+++ b/src/AuroraLib.Core/Text/ValueStringBuilder.cs
@@ -14,11 +14,7 @@ namespace AuroraLib.Core.Text
 {
     public ref partial struct ValueStringBuilder
     {
-#if NET20_OR_GREATER || NETSTANDARD2_0
-        private char[] _arrayToReturnToPool;
-#else
         private char[]? _arrayToReturnToPool;
-#endif
         private Span<char> _chars;
         private int _pos;
 
@@ -309,7 +305,7 @@ namespace AuroraLib.Core.Text
 
             _chars.Slice(0, _pos).CopyTo(poolArray);
 
-            char[] toReturn = _arrayToReturnToPool;
+            char[]? toReturn = _arrayToReturnToPool;
             _chars = _arrayToReturnToPool = poolArray;
             if (toReturn != null)
             {
@@ -320,7 +316,7 @@ namespace AuroraLib.Core.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
-            char[] toReturn = _arrayToReturnToPool;
+            char[]? toReturn = _arrayToReturnToPool;
             this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
             if (toReturn != null)
             {

--- a/src/AuroraLib.Core/UInt24.cs
+++ b/src/AuroraLib.Core/UInt24.cs
@@ -46,16 +46,16 @@ namespace AuroraLib.Core
         public override string ToString() => Value.ToString();
 
         /// <inheritdoc/>
-        public string ToString(IFormatProvider provider) => Value.ToString(provider);
+        public string ToString(IFormatProvider? provider) => Value.ToString(provider);
 
         /// <inheritdoc/>
-        public string ToString(string format) => Value.ToString(format);
+        public string ToString(string? format) => Value.ToString(format);
 
         /// <inheritdoc/>
-        public string ToString(string format, IFormatProvider provider) => Value.ToString(format, provider);
+        public string ToString(string? format, IFormatProvider? provider) => Value.ToString(format, provider);
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is UInt24 ui24 && ui24.Value == Value;
+        public override bool Equals(object? obj) => obj is UInt24 ui24 && ui24.Value == Value;
 
         /// <inheritdoc/>
         public bool Equals(UInt24 other) => this == other;
@@ -67,7 +67,7 @@ namespace AuroraLib.Core
         public override int GetHashCode() => Value.GetHashCode();
 
         /// <inheritdoc/>
-        public int CompareTo(object value)
+        public int CompareTo(object? value)
         {
             if (value == null)
                 return 1;
@@ -127,49 +127,49 @@ namespace AuroraLib.Core
 
         #region IConvertible
 
-        bool IConvertible.ToBoolean(IFormatProvider provider)
+        bool IConvertible.ToBoolean(IFormatProvider? provider)
             => Convert.ToBoolean(Value, provider);
 
-        char IConvertible.ToChar(IFormatProvider provider)
+        char IConvertible.ToChar(IFormatProvider? provider)
             => Convert.ToChar(Value, provider);
 
-        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        sbyte IConvertible.ToSByte(IFormatProvider? provider)
             => Convert.ToSByte(Value, provider);
 
-        byte IConvertible.ToByte(IFormatProvider provider)
+        byte IConvertible.ToByte(IFormatProvider? provider)
             => Convert.ToByte(Value, provider);
 
-        short IConvertible.ToInt16(IFormatProvider provider)
+        short IConvertible.ToInt16(IFormatProvider? provider)
             => Convert.ToInt16(Value, provider);
 
-        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        ushort IConvertible.ToUInt16(IFormatProvider? provider)
             => Convert.ToUInt16(Value, provider);
 
-        int IConvertible.ToInt32(IFormatProvider provider)
+        int IConvertible.ToInt32(IFormatProvider? provider)
             => Convert.ToInt32(Value, provider);
 
-        uint IConvertible.ToUInt32(IFormatProvider provider)
+        uint IConvertible.ToUInt32(IFormatProvider? provider)
             => Value;
 
-        long IConvertible.ToInt64(IFormatProvider provider)
+        long IConvertible.ToInt64(IFormatProvider? provider)
             => Convert.ToInt64(Value, provider);
 
-        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        ulong IConvertible.ToUInt64(IFormatProvider? provider)
             => Convert.ToUInt64(Value, provider);
 
-        float IConvertible.ToSingle(IFormatProvider provider)
+        float IConvertible.ToSingle(IFormatProvider? provider)
             => Convert.ToSingle(Value, provider);
 
-        double IConvertible.ToDouble(IFormatProvider provider)
+        double IConvertible.ToDouble(IFormatProvider? provider)
             => Convert.ToDouble(Value, provider);
 
-        decimal IConvertible.ToDecimal(IFormatProvider provider)
+        decimal IConvertible.ToDecimal(IFormatProvider? provider)
             => Convert.ToDecimal(Value, provider);
 
-        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        DateTime IConvertible.ToDateTime(IFormatProvider? provider)
             => Convert.ToDateTime(Value, provider);
 
-        object IConvertible.ToType(Type type, IFormatProvider provider)
+        object IConvertible.ToType(Type type, IFormatProvider? provider)
             => Convert.ChangeType(Value, type, provider);
 
         /// <inheritdoc/>


### PR DESCRIPTION
.NET standard/framework CSharp version bumped to C# 8, exclusively to support the nullable syntax